### PR TITLE
Fix broken websocket-driver version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13123,13 +13123,13 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.2.tgz",
-      "integrity": "sha512-RRTAkzsGiOP8PwGwLfd/H0NbotLXyS5zxg4EbuQ2K3aNqgUOVbOzBKKvTXzUsKiwVs+pBpBtqBYHj6PS6JVXDQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "requires": {
-        "http-parser-js": ">= 0.4.0, < 0.4.11",
-        "safe-buffer": ">= 5.1.0",
-        "websocket-extensions": ">= 0.1.1"
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {


### PR DESCRIPTION
websocket-driver 0.7.2 [was unpublished](https://github.com/faye/websocket-driver-node/issues/34) so `npm install` will fail.